### PR TITLE
remove test clock. Clean lint check. Pull out m_fs_rcv_clk

### DIFF
--- a/rev2/rtl/v1_slave/s10aib/rtl/maib_ch.v
+++ b/rev2/rtl/v1_slave/s10aib/rtl/maib_ch.v
@@ -310,6 +310,7 @@ ndaibadapt_wrap  ndut(
                       .pld_pma_tx_qpi_pulldn(1'b0),
                       .pld_pma_tx_qpi_pullup(1'b1),    
                       .pld_pma_rx_qpi_pullup(1'b1),
+                      .pld_pma_aib_tx_clk(1'b0),
     
     // PLD DCM input
                       .pld_rx_clk1_dcm(rx_coreclkin),
@@ -463,6 +464,7 @@ ndaibadapt_wrap  ndut(
                       .pld_pll_cal_done(),
                       .pld_pma_adapt_done(),
                       .pld_pma_clkdiv_rx_user(fs_mac_rdy),
+                      .pld_pma_clkdiv_tx_user(),
                       .pld_pma_fpll_clk0bad(),
                       .pld_pma_fpll_clk1bad(),
                       .pld_pma_fpll_clksel(),
@@ -525,6 +527,7 @@ ndaibadapt_wrap  ndut(
                       .pld_pcs_tx_clk_out2_dcm(),
 
     //JTAG input
+                      .iatpg_pipeline_global_en(1'b0),
                       .iatpg_scan_clk_in0(1'b1),
                       .iatpg_scan_clk_in1(1'b1),
                       .iatpg_scan_in0(1'b0),

--- a/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/aib_top_v2m.v
+++ b/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/aib_top_v2m.v
@@ -130,11 +130,11 @@ module aib_top_v2m
     //======================================================================================
    // DFT signals
    input                                                          i_scan_clk,     //ATPG Scan shifting clock from Test Pad.  
-   input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
-   input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
-   input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
+// input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
+// input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
                                                                                   //The divided down clock is for different clock domain at
                                                                                   //speed test.
    //Channel ATPG signals from/to CODEC
@@ -248,11 +248,11 @@ module aib_top_v2m
        .i_tx_elane_clk                  (m_rd_clk[TOTAL_CHNL_NUM-1:0]),
        .o_tx_elane_data                 (data_out[TOTAL_CHNL_NUM*78-1:0]),
        .i_scan_clk                      (i_scan_clk),
-       .i_test_clk_125m                 (i_test_clk_125m),
-       .i_test_clk_1g                   (i_test_clk_1g),
-       .i_test_clk_250m                 (i_test_clk_250m),
-       .i_test_clk_500m                 (i_test_clk_500m),
-       .i_test_clk_62m                  (i_test_clk_62m),
+       .i_test_clk_125m                 (1'b0),
+       .i_test_clk_1g                   (1'b0),
+       .i_test_clk_250m                 (1'b0),
+       .i_test_clk_500m                 (1'b0),
+       .i_test_clk_62m                  (1'b0),
        .i_test_c3adapt_scan_in          (i_test_c3adapt_scan_in/*[TOTAL_CHNL_NUM-1:0][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]*/),
        .i_test_c3adapt_tcb_static_common({58'h0, i_test_scan_en, i_test_scan_mode}),
        .i_jtag_rstb_in                  (i_jtag_rstb),  // Templated

--- a/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/aib_top_wrapper_v2m.sv
+++ b/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/aib_top_wrapper_v2m.sv
@@ -146,11 +146,11 @@ module aib_top_wrapper_v2m
    input                                                          i_scan_clk,     //ATPG Scan shifting clock from Test Pad.  
    input                                                          i_test_scan_en,
    input                                                          i_test_scan_mode,
-   input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
-   input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
-   input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
+// input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
+// input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
                                                                                   //The divided down clock is for different clock domain at
                                                                                   //speed test.
    //Channel ATPG signals from/to CODEC
@@ -612,11 +612,11 @@ assign                          LO = 1'b0;
                     .i_scan_clk                  (i_scan_clk), 
                     .i_test_scan_en              (i_test_scan_en),
                     .i_test_scan_mode            (i_test_scan_mode),
-                    .i_test_clk_125m             (i_test_clk_125m), 
-                    .i_test_clk_1g               (i_test_clk_1g), 
-                    .i_test_clk_250m             (i_test_clk_250m), 
-                    .i_test_clk_500m             (i_test_clk_500m), 
-                    .i_test_clk_62m              (i_test_clk_62m), 	      
+                //  .i_test_clk_125m             (i_test_clk_125m), 
+                //  .i_test_clk_1g               (i_test_clk_1g), 
+                //  .i_test_clk_250m             (i_test_clk_250m), 
+                //  .i_test_clk_500m             (i_test_clk_500m), 
+                //  .i_test_clk_62m              (i_test_clk_62m), 	      
                     .i_test_c3adapt_scan_in      (i_test_c3adapt_scan_in),
 	            .o_test_c3adapt_scan_out     (o_test_c3adapt_scan_out),
                     .i_jtag_clkdr                (i_jtag_clkdr),   

--- a/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/c3aibadapt_wrap.v
+++ b/rev2/rtl/v2_master/c3aibadapt_wrap/rtl/c3aibadapt_wrap.v
@@ -294,16 +294,16 @@ module c3aibadapt_wrap
  );
 
     //List the detail bit assignment corresponding to the AIB spec 1.1
+    assign ms_tx_transfer_en = ms_sideband[78];
+    assign ms_rx_transfer_en = ms_sideband[75];
+    assign sl_rx_transfer_en = sl_sideband[70];
+    assign sl_tx_transfer_en = sl_sideband[64];
     wire ms_osc_transfer_en = ms_sideband[80];
-    wire ms_tx_transfer_en = ms_sideband[78];
-    wire ms_rx_transfer_en = ms_sideband[75];
     wire ms_rx_dll_lock = ms_sideband[74];
     wire ms_tx_dcc_cal_done = ms_sideband[68];
     wire sl_osc_transfer_en = sl_sideband[72]; 
-    wire sl_rx_transfer_en = sl_sideband[70];
     wire sl_rx_dll_dcc_lock_req = sl_sideband[69];
     wire sl_rx_dll_lock = sl_sideband[69];
-    wire sl_tx_transfer_en = sl_sideband[64];
     wire sl_tx_dll_dcc_lock_req = sl_sideband[63];
     wire sl_tx_dcc_cal_done = sl_sideband[31];
  

--- a/rev2/rtl/v2_slave/aib_slv/aib_slv.v
+++ b/rev2/rtl/v2_slave/aib_slv/aib_slv.v
@@ -225,12 +225,12 @@ module aib_slv
     input                                      i_por_aib_vcchssi, //output of por circuit 
     input                                      i_por_aib_vccl, //From AUX. From S10 
     output wire                                o_por_aib_vcchssi, // Feed through pass to next channel 
-    output wire                                o_por_aib_vccl, // 
+    output wire                                o_por_aib_vccl // 
 
 
 // Go to next Channel AIB
-    input  [12:0]                               i_aibdftdll2adjch, // DCC/DLL observability from previous channel
-    output wire [12:0]                          o_aibdftdll2adjch  // DCC/DLL observability Go to next channel 
+//  input  [12:0]                               i_aibdftdll2adjch, // DCC/DLL observability from previous channel
+//  output wire [12:0]                          o_aibdftdll2adjch  // DCC/DLL observability Go to next channel 
  );
 
     wire                fs_fwd_clk;
@@ -635,7 +635,7 @@ module aib_slv
                                     .ojtag_rx_scan_out_chain(o_jtag_bs_chain_out), 
                                     .por_aib_vcchssi_out(o_por_aib_vcchssi), 
                                     .por_aib_vccl_out   (o_por_aib_vccl), 
-                                    .oaibdftdll2adjch   (o_aibdftdll2adjch), 
+                                    .oaibdftdll2adjch   (), 
                                     .ohssi_tx_data_in   (din[39:0]), 
                                     // Inouts
                                     .aib0               (io_aib0),       

--- a/rev2/rtl/v2_slave/aibadapt_wrap/rtl/aib_top_v2s.v
+++ b/rev2/rtl/v2_slave/aibadapt_wrap/rtl/aib_top_v2s.v
@@ -70,6 +70,8 @@ module aib_top_v2s
 // output [TOTAL_CHNL_NUM*61-1:0]                                 o_chnl_ssr, // Slow shift chain path, left unconnected if not used
    output [TOTAL_CHNL_NUM-1:0]                                    m_fs_fwd_clk, // clock used for tx data transmission
    output [TOTAL_CHNL_NUM-1:0]                                    m_fs_fwd_div2_clk, // half rate of tx data transmission clock
+   output [TOTAL_CHNL_NUM-1:0]                                    m_fs_rcv_clk,
+   output [TOTAL_CHNL_NUM-1:0]                                    m_fs_rcv_div2_clk,
 // output [TOTAL_CHNL_NUM*40-1:0]                                 o_tx_pma_data, // Directed bump tx data sync path
    input  [TOTAL_CHNL_NUM-1:0]                                    m_rd_clk, //Clock for phase compensation fifo
    output [TOTAL_CHNL_NUM*78-1:0]                                 data_out, // data out for phase compensation fifo
@@ -141,11 +143,11 @@ module aib_top_v2s
     //======================================================================================
    // DFT signals
    input                                                          i_scan_clk,     //ATPG Scan shifting clock from Test Pad.  
-   input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
-   input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
-   input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
+// input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
+// input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
                                                                                   //The divided down clock is for different clock domain at
                                                                                   //speed test.
    //Channel ATPG signals from/to CODEC
@@ -194,8 +196,8 @@ module aib_top_v2s
 //     .o_chnl_ssr                      (),
        .m_fs_fwd_clk                    (m_fs_fwd_clk[TOTAL_CHNL_NUM-1:0]),
        .m_fs_fwd_div2_clk               (m_fs_fwd_div2_clk[TOTAL_CHNL_NUM-1:0]),
-       .m_fs_rcv_clk                    (),
-       .m_fs_rcv_div2_clk               (),
+       .m_fs_rcv_clk                    (m_fs_rcv_clk[TOTAL_CHNL_NUM-1:0]),
+       .m_fs_rcv_div2_clk               (m_fs_rcv_div2_clk),
 //     .o_tx_pma_data                   (),
        .ns_mac_rdy                      (ns_mac_rdy[TOTAL_CHNL_NUM-1:0]),
        .ns_adapter_rstn                 (ns_adapter_rstn[TOTAL_CHNL_NUM-1:0]),
@@ -269,11 +271,11 @@ module aib_top_v2s
        .m_rd_clk                        (m_rd_clk[TOTAL_CHNL_NUM-1:0]),
        .data_out                        (data_out[TOTAL_CHNL_NUM*78-1:0]),
        .i_scan_clk                      (i_scan_clk),
-       .i_test_clk_125m                 (i_test_clk_125m),
-       .i_test_clk_1g                   (i_test_clk_1g),
-       .i_test_clk_250m                 (i_test_clk_250m),
-       .i_test_clk_500m                 (i_test_clk_500m),
-       .i_test_clk_62m                  (i_test_clk_62m),
+       .i_test_clk_125m                 (1'b0),
+       .i_test_clk_1g                   (1'b0),
+       .i_test_clk_250m                 (1'b0),
+       .i_test_clk_500m                 (1'b0),
+       .i_test_clk_62m                  (1'b0),
        .i_test_c3adapt_scan_in          (i_test_c3adapt_scan_in/*[TOTAL_CHNL_NUM-1:0][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]*/),
        .i_test_c3adapt_tcb_static_common({58'h0, i_test_scan_en, i_test_scan_mode}),
        .i_jtag_rstb_in                  (i_jtag_rstb),  // Templated

--- a/rev2/rtl/v2_slave/aibadapt_wrap/rtl/aib_top_wrapper_v2s.sv
+++ b/rev2/rtl/v2_slave/aibadapt_wrap/rtl/aib_top_wrapper_v2s.sv
@@ -52,6 +52,8 @@ module aib_top_wrapper_v2s
    input [TOTAL_CHNL_NUM-1:0]                                     m_ns_rcv_clk, //i_tx_pma_clk, sent over to the other chiplet to be used for the clock 
    output [TOTAL_CHNL_NUM-1:0]                                    m_fs_fwd_clk, //o_tx_transfer_clk, clock used for tx data transmission
    output [TOTAL_CHNL_NUM-1:0]                                    m_fs_fwd_div2_clk, // o_tx_transfer_div2_clk, half rate of tx data transmission clock
+   output [TOTAL_CHNL_NUM-1:0]                                    m_fs_rcv_clk,
+   output [TOTAL_CHNL_NUM-1:0]                                    m_fs_rcv_div2_clk,
    output [TOTAL_CHNL_NUM*78-1:0]                                 data_out, //o_tx_pma_data, Directed bump tx data sync path
    input  [TOTAL_CHNL_NUM-1:0]                                    m_rd_clk, //Clock for phase compensation fifo
  //=================================================================================================
@@ -163,17 +165,17 @@ module aib_top_wrapper_v2s
 
    //
    input                                                          i_osc_clk,     // test clock from c4 bump, may tie low for User if not used
-   output                                                         o_aibaux_osc_clk, // osc clk output to test C4 bump to characterize the oscillator, User may use this clock to connect with i_test_clk_1g
+   output                                                         o_aibaux_osc_clk, // osc clk output to test C4 bump to characterize the oscillator 
     //======================================================================================
    // DFT signals
    input                                                          i_scan_clk,     //ATPG Scan shifting clock from Test Pad.  
    input                                                          i_test_scan_en,
    input                                                          i_test_scan_mode,
-   input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
-   input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
-   input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
-   input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_1g,  //1GHz free running direct accessed ATPG at speed clock.
+// input                                                          i_test_clk_125m,//Divided down from i_test_clk_1g. 
+// input                                                          i_test_clk_250m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_500m,//Divided down from i_test_clk_1g.
+// input                                                          i_test_clk_62m, //Divided down from i_test_clk_1g.
                                                                                   //The divided down clock is for different clock domain at
                                                                                   //speed test.
    //Channel ATPG signals from/to CODEC
@@ -245,6 +247,8 @@ assign                          LO = 1'b0;
                     .m_ns_rcv_clk                (m_ns_rcv_clk), 
                     .m_fs_fwd_clk                (m_fs_fwd_clk), 
                     .m_fs_fwd_div2_clk           (m_fs_fwd_div2_clk),        // Not used 
+                    .m_fs_rcv_clk                (m_fs_rcv_clk),
+                    .m_fs_rcv_div2_clk           (m_fs_rcv_div2_clk),
                     .m_rd_clk                    (m_rd_clk),
                     .data_out                    (data_out),
 		    .ns_mac_rdy                  (ns_mac_rdy),
@@ -657,11 +661,11 @@ assign                          LO = 1'b0;
                     .i_scan_clk                  (i_scan_clk), 
                     .i_test_scan_en              (i_test_scan_en),
                     .i_test_scan_mode            (i_test_scan_mode),
-                    .i_test_clk_125m             (i_test_clk_125m), 
-                    .i_test_clk_1g               (i_test_clk_1g), 
-                    .i_test_clk_250m             (i_test_clk_250m), 
-                    .i_test_clk_500m             (i_test_clk_500m), 
-                    .i_test_clk_62m              (i_test_clk_62m), 	      
+               //   .i_test_clk_125m             (i_test_clk_125m), 
+               //   .i_test_clk_1g               (i_test_clk_1g), 
+               //   .i_test_clk_250m             (i_test_clk_250m), 
+               //   .i_test_clk_500m             (i_test_clk_500m), 
+               //   .i_test_clk_62m              (i_test_clk_62m), 	      
                     .i_test_c3adapt_scan_in      (i_test_c3adapt_scan_in),
 	            .o_test_c3adapt_scan_out     (o_test_c3adapt_scan_out),
                     .i_jtag_clkdr                (i_jtag_clkdr),   


### PR DESCRIPTION
Signed-off-by: Julie Zhang <julie.zhang@intel.com>